### PR TITLE
Add NKSR22/arduino-ibt2-motor-driver

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8417,3 +8417,4 @@ https://github.com/stm32duino/IIS2DULPX
 https://github.com/stm32duino/ISM330IS
 https://github.com/stm32duino/ILPS22QS
 https://github.com/fulda1/SUSI2
+https://github.com/NKSR22/arduino-ibt2-motor-driver


### PR DESCRIPTION
Adds the IBT-2 Motor Driver library by NKSR22 to the registry.